### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,9 @@
   "devDependencies": {
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-concat": "^0.5.0"
+  },
+  "spm": {
+    "main": "snabbt.js",
+    "ignore": ["docs", "src"]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/snabbt.js

---

It is a browser-side package manager popular in China, suppling a complete lifecycle managment of package via [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of snabbt.js in spmjs, I can add it for your account after signing in http://spmjs.io .

spmjs/spm#781