### PR TITLE
Fixed a typo on index.html Line 94

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -91,7 +91,7 @@
         <h4>Limitations</h4>
         <ul>
           <li>All transforms work on pixels or radians. Any unit conversion has to be done beforehand.</li>
-          <li>No abritrary property animations, e.g. colors, padding, margin or line height animations.</li>
+          <li>No arbitrary property animations, e.g. colors, padding, margin or line height animations.</li>
           <li>For performance reasons, snabbt.js never queries the DOM. This means that in some cases you need to store end transforms yourself.</li>
         </ul>
       </section>


### PR DESCRIPTION
Before: <li>No abritrary property animations, e.g. colors, padding, margin or line height animations.</li>
After: <li>No arbitrary property animations, e.g. colors, padding, margin or line height animations.</li>